### PR TITLE
Add show time link to main page

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -8,3 +8,7 @@
     <h1 class="display-4">Welcome</h1>
     <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
+
+<div class="d-flex justify-content-center align-items-center" style="height: 100vh;">
+    <div id="show-time" class="display-4"></div>
+</div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -24,6 +24,9 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                        </li>
+                        <li class="nav-item" id="show-time-link" onclick="toggleTimeDisplay()">
+                            <a class="nav-link text-dark" href="#">Show Time</a>
                         </li>
                     </ul>
                 </div>

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -2,3 +2,47 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+let timeInterval;
+
+function showCurrentTime() {
+    const now = new Date();
+    const hours = now.getHours();
+    const minutes = now.getMinutes();
+    const seconds = now.getSeconds();
+
+    const timeString = `
+        <span style="color: red;">${hours.toString().padStart(2, '0')}</span>:
+        <span style="color: green;">${minutes.toString().padStart(2, '0')}</span>:
+        <span style="color: blue;">${seconds.toString().padStart(2, '0')}</span>
+    `;
+
+    const showTimeElement = document.getElementById('show-time');
+    showTimeElement.innerHTML = timeString;
+    showTimeElement.style.transition = 'all 0.5s ease-in-out';
+    showTimeElement.style.transform = 'scale(1.1)';
+    setTimeout(() => {
+        showTimeElement.style.transform = 'scale(1)';
+    }, 500);
+}
+
+function toggleTimeDisplay() {
+    const showTimeLink = document.getElementById('show-time-link');
+    const showTimeElement = document.getElementById('show-time');
+
+    if (showTimeLink.textContent === 'Show Time') {
+        showTimeLink.textContent = 'Hide Time';
+        showTimeElement.style.display = 'block';
+        showCurrentTime();
+        timeInterval = setInterval(showCurrentTime, 1000);
+    } else {
+        showTimeLink.textContent = 'Show Time';
+        showTimeElement.style.display = 'none';
+        clearInterval(timeInterval);
+    }
+}
+
+document.getElementById('show-time-link').addEventListener('click', function(event) {
+    event.preventDefault();
+    toggleTimeDisplay();
+});


### PR DESCRIPTION
Add a link to show the current local time on the main page.

* **Layout Changes**
  - Add a new `<li class="nav-item">` element with `id="show-time-link"` and `onclick="toggleTimeDisplay()"` to the navigation bar in `Pages/Shared/_Layout.cshtml`.
  - Add a link with the text "Show Time" within the new `<li>` element.

* **JavaScript Functions**
  - Add `showCurrentTime()` function in `wwwroot/js/site.js` to fetch and display the current local time with different colors for hours, minutes, and seconds.
  - Add `toggleTimeDisplay()` function to toggle the time display and change the link text between "Show Time" and "Hide Time".
  - Add an event listener to the `show-time-link` element to call `toggleTimeDisplay()` on click.

* **Main Page Changes**
  - Add a new `<div>` element with `id="show-time"` and class `display-4` to `Pages/Index.cshtml` to display the current local time.
  - Wrap the `#show-time` element in a `div` with the class `d-flex justify-content-center align-items-center` for centering.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Cesara-ms/aspnetdemo/pull/1?shareId=5f1f9c92-8e73-4d50-88a8-c52e8848c717).